### PR TITLE
Fix remove method in KeysManager.sol

### DIFF
--- a/src/BallotsManager.sol
+++ b/src/BallotsManager.sol
@@ -27,7 +27,7 @@ contract BallotsManager is ValidatorsManager, DemoData {
                 break;
             }
         }
-        bool disabledValidatorIsAdded = false;
+
         for (uint j = 0; j < disabledValidators.length; j++) {
             if (disabledValidators[j] == miningKey) throw; //validator is already removed before
         }

--- a/src/KeysManager.sol
+++ b/src/KeysManager.sol
@@ -69,10 +69,14 @@ contract KeysManager is owned, KeyClass, ValidatorClass, BallotClass {
     */
     function remove(address[] array, uint index) internal returns(address[] value) {
         if (index >= array.length) return;
-
-        address[] arrayNew;
-        for (uint i = index; i<array.length-1; i++){
-            arrayNew[i] = array[i+1];
+        
+        address[] memory arrayNew = new address[](array.length-1);
+        for (uint i = 0; i<arrayNew.length; i++){
+            if(i != index && i<index){
+                arrayNew[i] = array[i];
+            } else {
+                arrayNew[i] = array[i+1];
+            }
         }
         delete array;
         return arrayNew;


### PR DESCRIPTION
#Commit https://github.com/oraclesorg/oracles-contract/pull/2/commits/6160fcd1b8ac92986f819bc9b3d74982fe728ac0 -
Removes unused variable.

#Commit https://github.com/oraclesorg/oracles-contract/pull/2/commits/dbcbe2a5be5944c001750a2cbf2245dd826d8a9f -
the current implementation doesn't take care of proper adjustment of `length` property and also leaves "0" 