### PR TITLE
add declaration for votingMiningKeysPair

### DIFF
--- a/src/KeysManager.sol
+++ b/src/KeysManager.sol
@@ -10,6 +10,7 @@ contract KeysManager is owned, KeyClass, ValidatorClass, BallotClass {
     int8 internal initialKeysLimit = 12;
     int8 internal licensesIssued = 0;
     int8 internal licensesLimit = 52;
+    mapping(address => address) votingMiningKeysPair;
     
     /**
     @notice Adds initial key


### PR DESCRIPTION
With latest `master` branch I wasn't able to run `dapp build` because it was throwing me an error:

```
src/KeysManager.sol:44:9: Error: Undeclared identifier.
        votingMiningKeysPair[votingAddr] = miningAddr;
        ^------------------^
```